### PR TITLE
Corrected loggers' name in case of C# generics, corrected SQL generation, prettified displayed SQL

### DIFF
--- a/Analogy.LogViewer.LoggersTree/Analogy.LogViewer.LoggersTree.csproj
+++ b/Analogy.LogViewer.LoggersTree/Analogy.LogViewer.LoggersTree.csproj
@@ -25,7 +25,7 @@
 		<GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
 		<Nullable>disable</Nullable>
 		<LangVersion>8.0</LangVersion>
-		<Version>1.0.1</Version>
+		<Version>1.0.2</Version>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net7.0-windows|AnyCPU'">

--- a/Analogy.LogViewer.LoggersTree/Analogy.LogViewer.LoggersTree.csproj
+++ b/Analogy.LogViewer.LoggersTree/Analogy.LogViewer.LoggersTree.csproj
@@ -59,7 +59,12 @@
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net471|AnyCPU'">
 	  <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
 	</PropertyGroup>
-
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net471' ">
+		<PackageReference Include="PolySharp" Version="1.12.1">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Analogy.CommonUtilities" Version="3.8.3" />
 		<PackageReference Include="Analogy.LogViewer.Interfaces" Version="3.8.3" />
@@ -133,4 +138,5 @@
 		  <LastGenOutput>Resources.Designer.cs</LastGenOutput>
 		</EmbeddedResource>
 	</ItemGroup>
+
 </Project>

--- a/Analogy.LogViewer.LoggersTree/LoggersTree/PrimaryFactory.cs
+++ b/Analogy.LogViewer.LoggersTree/LoggersTree/PrimaryFactory.cs
@@ -17,6 +17,7 @@ namespace Analogy.LogViewer.LoggersTree.LoggersTree
 
         public override IEnumerable<IAnalogyChangeLog> ChangeLog { get; set; } = new List<AnalogyChangeLog>
         {
+            new AnalogyChangeLog("Corrected loggers' name in case of C# generics, corrected SQL generation, prettified displayed SQL",AnalogChangeLogType.Bug, "CAMAG",new DateTime(2023, 04, 04)),
             new AnalogyChangeLog("Corrected query and added auto resize",AnalogChangeLogType.Bug, "CAMAG",new DateTime(2023, 03, 22))
         };
         public override IEnumerable<string> Contributors { get; set; } = new List<string> { "CAMAG" };

--- a/Analogy.LogViewer.LoggersTree/LoggersTree/UcLoggersTree.Designer.cs
+++ b/Analogy.LogViewer.LoggersTree/LoggersTree/UcLoggersTree.Designer.cs
@@ -201,12 +201,16 @@ namespace Analogy.LogViewer.LoggersTree.LoggersTree
             // 
             // TxtQuery
             // 
+            TxtQuery.AcceptsReturn = true;
+            TxtQuery.AcceptsTab = true;
             TxtQuery.Dock = System.Windows.Forms.DockStyle.Fill;
             TxtQuery.Location = new System.Drawing.Point(0, 0);
             TxtQuery.Multiline = true;
             TxtQuery.Name = "TxtQuery";
+            TxtQuery.ScrollBars = System.Windows.Forms.ScrollBars.Both;
             TxtQuery.Size = new System.Drawing.Size(733, 102);
             TxtQuery.TabIndex = 5;
+            TxtQuery.WordWrap = false;
             // 
             // UcLoggersTree
             // 

--- a/Analogy.LogViewer.LoggersTree/Utils/SqlPrettify.cs
+++ b/Analogy.LogViewer.LoggersTree/Utils/SqlPrettify.cs
@@ -1,0 +1,137 @@
+﻿//Adapted from SqlPrettify, Version=1.0.3.0, MIT license
+
+using System;
+using System.Collections.Generic;
+
+namespace Analogy.LogViewer.LoggersTree.Utils
+{
+    public class SqlPrettify
+    {
+        public static string Pretty(string q)
+        {
+            q += " ";
+            int num1 = 0;
+            string str1 = string.Empty;
+            int num2 = 0;
+            List<string> stringList1 = new List<string>()
+                                       {
+                                           "select",
+                                           "from",
+                                           "where",
+                                           "inner",
+                                           "outer",
+                                           "left",
+                                           "right",
+                                           "full",
+                                           "join",
+                                           "group",
+                                           "order",
+                                           "by"
+                                       };
+            List<string> stringList2 = new List<string>()
+                                       {
+                                           "and",
+                                           "or",
+                                           "between"
+                                       };
+            List<string> stringList3 = new List<string>()
+                                       {
+                                           "left",
+                                           "right",
+                                           "inner",
+                                           "outer",
+                                           "full"
+                                       };
+            List<string> stringList4 = new List<string>()
+                                       {
+                                           "order",
+                                           "group"
+                                       };
+            string str2 = string.Empty;
+            string str3 = string.Empty;
+            string str4 = string.Empty;
+            for (int index = 0; index < q.Length; ++index)
+            {
+                char ch = q[index];
+                str4 += ch.ToString();
+                if (ch == '\'' && q[index - 1] != '\\')
+                    num2 = (num2 + 1) % 2;
+                if (num2 == 0 && ch == ',')
+                    str4 += " ";
+            }
+            q = str4;
+            foreach (char ch in q)
+            {
+                int num3;
+                switch (ch)
+                {
+                    case '\n':
+                    case '\r':
+                    case ' ':
+                        num3 = 0;
+                        break;
+                    default:
+                        num3 = ch != '\t' ? 1 : 0;
+                        break;
+                }
+                if (num3 != 0)
+                {
+                    str3 += ch.ToString();
+                    if (ch == '(')
+                        ++num1;
+                    if (ch == ')')
+                        --num1;
+                }
+                else if (str3 != string.Empty)
+                {
+                    if (stringList1.Contains(str3.Trim().ToLower()))
+                    {
+                        if (str3.Trim().ToLower() == "join")
+                        {
+                            if (stringList3.Contains(str1))
+                                str2 = str2.Substring(0, str2.Length - 1 - (num1 + 1) * 4) + " " + " " + str3 + Environment.NewLine + SpaceAdder((num1 + 1) * 4);
+                            else
+                                str2 = str2 + Environment.NewLine + SpaceAdder(num1 * 4) + str3 + Environment.NewLine + SpaceAdder((num1 + 1) * 4);
+                        }
+                        else if (str3.Trim().ToLower() == "by")
+                        {
+                            if (stringList4.Contains(str1))
+                                str2 = str2.Substring(0, str2.Length - 1 - (num1 + 1) * 4) + " " + " " + str3 + Environment.NewLine + SpaceAdder((num1 + 1) * 4);
+                            else
+                                str2 = str2 + str3 + Environment.NewLine + SpaceAdder((num1 + 1) * 4);
+                        }
+                        else
+                            str2 = str2 + Environment.NewLine + SpaceAdder(num1 * 4) + str3 + Environment.NewLine + SpaceAdder((num1 + 1) * 4);
+                    }
+                    else if (stringList2.Contains(str3.Trim().ToLower()))
+                    {
+                        str2 = str2 + Environment.NewLine + SpaceAdder((num1 + 1) * 4) + str3 + " ";
+                    }
+                    else
+                    {
+                        string str5 = str3;
+                        str2 = str5[^1] != ',' ? str2 + str3 + " " : str2 + str3 + Environment.NewLine + SpaceAdder((num1 + 1) * 4);
+                    }
+                    str1 = str3.ToLower();
+                    str3 = string.Empty;
+                }
+            }
+            if (str2[0] != '\n')
+                return str2;
+            string str6 = str2;
+            int length1 = str6.Length;
+            int startIndex = 1;
+            int num4 = startIndex;
+            int length2 = length1 - num4;
+            return str6.Substring(startIndex, length2);
+        }
+
+        private static string SpaceAdder(int spaces)
+        {
+            string str = string.Empty;
+            for (; spaces > 0; --spaces)
+                str += " ";
+            return str;
+        }
+    }
+}

--- a/Analogy.LogViewer.LoggersTree/Utils/SqlPrettify.cs
+++ b/Analogy.LogViewer.LoggersTree/Utils/SqlPrettify.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace Analogy.LogViewer.LoggersTree.Utils
 {
@@ -60,21 +61,14 @@ namespace Analogy.LogViewer.LoggersTree.Utils
                     str4 += " ";
             }
             q = str4;
-            foreach (char ch in q)
+            bool isText = false;
+            for (int index = 0; index < q.Length; index++)
             {
-                int num3;
-                switch (ch)
-                {
-                    case '\n':
-                    case '\r':
-                    case ' ':
-                        num3 = 0;
-                        break;
-                    default:
-                        num3 = ch != '\t' ? 1 : 0;
-                        break;
-                }
-                if (num3 != 0)
+                char ch = q[index];
+                bool isSpace = ch == '\n' || ch == '\r' || ch == ' ' || ch == '\t';
+                if (ch == '\'' && q[index - 1] != '\\')
+                    isText = !isText;
+                if (!isSpace || isText)
                 {
                     str3 += ch.ToString();
                     if (ch == '(')


### PR DESCRIPTION
- At least with Serilog, in case of loggers from C# generic classes, the generated name and tree was wrong
  - Escaping [ and = in SQL from these names
- Corrected SQL query when child should be display but not parent
- Prettify displayed SQL to more easily debug the query (code adapted from an MIT licensed nuget package)