### PR TITLE
🐛 Corrected tree expand issue

### DIFF
--- a/Analogy.LogViewer.LoggersTree/Analogy.LogViewer.LoggersTree.csproj
+++ b/Analogy.LogViewer.LoggersTree/Analogy.LogViewer.LoggersTree.csproj
@@ -13,7 +13,7 @@
 		<PackageIcon>icon.png</PackageIcon>
 		<PackageIconUrl />
 		<Description>Loggers tree extension</Description>
-		<VersionPrefix>3.0.0</VersionPrefix>
+		<VersionPrefix>3.0.1</VersionPrefix>
 		<VersionSuffix></VersionSuffix>
 	</PropertyGroup>
 

--- a/Analogy.LogViewer.LoggersTree/LoggersTree/PrimaryFactory.cs
+++ b/Analogy.LogViewer.LoggersTree/LoggersTree/PrimaryFactory.cs
@@ -17,6 +17,7 @@ namespace Analogy.LogViewer.LoggersTree.LoggersTree
 
         public override IEnumerable<IAnalogyChangeLog> ChangeLog { get; set; } = new List<AnalogyChangeLog>
         {
+            new AnalogyChangeLog("Corrected tree expansion", AnalogChangeLogType.Bug, "CAMAG", new DateTime(2023, 11, 21), ""),
             new AnalogyChangeLog("Update Nuget dependencies", AnalogChangeLogType.None, "Lior Banai", new DateTime(2023, 08, 04), ""),
             new AnalogyChangeLog("Corrected loggers' name in case of C# generics, corrected SQL generation, prettified displayed SQL", AnalogChangeLogType.Bug, "CAMAG", new DateTime(2023, 04, 04), ""),
             new AnalogyChangeLog("Corrected query and added auto resize", AnalogChangeLogType.Bug, "CAMAG", new DateTime(2023, 03, 22), ""),

--- a/Analogy.LogViewer.LoggersTree/LoggersTree/UcLoggersTree.cs
+++ b/Analogy.LogViewer.LoggersTree/LoggersTree/UcLoggersTree.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Timers;
 using System.Windows.Forms;
 
@@ -78,6 +79,10 @@ namespace Analogy.LogViewer.LoggersTree.LoggersTree
 
         private void ReadAll()
         {
+            if (IsDisposed)
+            {
+                return;
+            }
             int sleep = 0;
             for (int i = 0; i < MsgQueue.Count; i++)
             {
@@ -96,7 +101,14 @@ namespace Analogy.LogViewer.LoggersTree.LoggersTree
             }
             if (!isInitialized)
             {
-                TrvLoggers.BeginInvoke((MethodInvoker)(() => { TrvLoggers.ExpandAll(); }));
+#pragma warning disable MA0134
+                Task.Factory.StartNew(() =>
+                {
+                    //wait for UI to be ready
+                    Thread.Sleep(5000);
+                    TrvLoggers.BeginInvoke((MethodInvoker)(() => { TrvLoggers.ExpandAll(); }));
+                }, TaskCreationOptions.LongRunning);
+#pragma warning restore MA0134
             }
             isInitialized = true;
         }

--- a/Analogy.LogViewer.LoggersTree/LoggersTree/UcLoggersTree.cs
+++ b/Analogy.LogViewer.LoggersTree/LoggersTree/UcLoggersTree.cs
@@ -26,6 +26,7 @@ namespace Analogy.LogViewer.LoggersTree.LoggersTree
         private readonly System.Timers.Timer timer;
         private DockPanel? dockPanel;
         private ControlContainer? container;
+        private bool isInitialized;
 
         private enum LogLevel
         {
@@ -93,7 +94,11 @@ namespace Analogy.LogViewer.LoggersTree.LoggersTree
                     sleep = 0;
                 }
             }
-            TrvLoggers.BeginInvoke((MethodInvoker)(() => { TrvLoggers.ExpandAll(); }));
+            if (!isInitialized)
+            {
+                TrvLoggers.BeginInvoke((MethodInvoker)(() => { TrvLoggers.ExpandAll(); }));
+            }
+            isInitialized = true;
         }
 
         private void ReadQueue(object? sender, ElapsedEventArgs elapsedEventArgs)

--- a/Analogy.LogViewer.LoggersTree/Properties/launchSettings.json
+++ b/Analogy.LogViewer.LoggersTree/Properties/launchSettings.json
@@ -5,13 +5,13 @@
     },
     "Analogy Release": {
       "commandName": "Executable",
-      "executablePath": "D:\\Projects\\Platypus\\Analogy.LogViewer\\Analogy.LogViewer\\Analogy\\bin\\Release\\net6.0-windows\\Analogy.exe",
-      "workingDirectory": "D:\\Projects\\Platypus\\Analogy.LogViewer\\Analogy.LogViewer\\Analogy\\bin\\Release\\net6.0-windows"
+      "executablePath": "D:\\Projects\\Analogy.LogViewer\\Analogy.LogViewer\\Analogy\\bin\\Release\\net8.0-windows\\Analogy.exe",
+      "workingDirectory": "D:\\Projects\\Analogy.LogViewer\\Analogy.LogViewer\\Analogy\\bin\\Release\\net8.0-windows"
     },
     "Analogy Debug": {
       "commandName": "Executable",
-      "executablePath": "D:\\Projects\\Platypus\\Analogy.LogViewer\\Analogy.LogViewer\\Analogy\\bin\\Debug\\net6.0-windows\\Analogy.exe",
-      "workingDirectory": "D:\\Projects\\Platypus\\Analogy.LogViewer\\Analogy.LogViewer\\Analogy\\bin\\Debug\\net6.0-windows"
+      "executablePath": "D:\\Projects\\Analogy.LogViewer\\Analogy.LogViewer\\Analogy\\bin\\Debug\\net8.0-windows\\Analogy.exe",
+      "workingDirectory": "D:\\Projects\\Analogy.LogViewer\\Analogy.LogViewer\\Analogy\\bin\\Debug\\net8.0-windows"
     }
   }
 }


### PR DESCRIPTION
Refreshing of the tree was always expanding again the whole tree, making folding useless.
Now, it will only expand the first time, after some time, to allow most logs files to be fully loaded in UI.